### PR TITLE
Allows custom platform-icons.json to be supplied

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = (file, opts) => {
 		return Promise.reject(new Error(`Platform ${opts.platform} is not supported.`));
 	}
 
-	const icons = platformIcons[opts.platform.toLowerCase()];
+	const icons = opts.platformIcons || platformIcons[opts.platform.toLowerCase()];
 	const resizeFn = path.extname(file) === '.svg' ? 'density' : 'resize';
 
 	const img = gm(file);

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,12 @@ Default: `process.cwd()`
 
 Directory to save the generated icons.
 
+##### platformIcons
+
+Type: `object`<br>
+Default: As per the specified platform (see below)
+
+Allows the user to specify their own custom filenames and image sizes for the generated output.  Refer to [this file](https://github.com/SamVerschueren/android-icon-list/blob/master/icons.json) for an example.
 
 ## Platforms
 

--- a/test-platform-icons.json
+++ b/test-platform-icons.json
@@ -1,0 +1,10 @@
+[
+	{
+		"file": "custom-25.png",
+		"dimension": 25
+	},
+	{
+		"file": "subdir/custom-60.png",
+		"dimension": 60
+	}
+]

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ import pathExists from 'path-exists';
 import tempfile from 'tempfile';
 import gm from 'gm';
 import pify from 'pify';
+import testPlatformIcons from './test-platform-icons';
 import fn from './';
 
 test.beforeEach(t => {
@@ -54,4 +55,20 @@ test('output size svg', async t => {
 
 	t.is(width, 40);
 	t.is(height, 40);
+});
+
+test('custom platform icons', async t => {
+	await fn('fixtures/icon.svg', {platform: 'ios', dest: t.context.tmp, platformIcons: testPlatformIcons});
+
+	const image1 = gm(path.join(t.context.tmp, 'custom-25.png'));
+	const {width: width1, height: height1} = await pify(image1.size.bind(image1))();
+
+	t.is(width1, 25);
+	t.is(height1, 25);
+
+	const image2 = gm(path.join(t.context.tmp, 'subdir', 'custom-60.png'));
+	const {width: width2, height: height2} = await pify(image2.size.bind(image2))();
+
+	t.is(width2, 60);
+	t.is(height2, 60);
 });


### PR DESCRIPTION
Allows the user to supply their own `platformIcons` object in which they can specify file/path-names and image sizes in case the desired outputs do not match the defaults which have been pulled in.